### PR TITLE
Simplify ECS interface

### DIFF
--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -161,6 +161,17 @@ impl QueryResult {
         (component_idx, begin..end)
     }
 
+    /// Get the corresponding key for an entity, if it was included in the query
+    pub fn key_for_entity(&self, entity: EntityId) -> Option<Key> {
+        // TODO: This lookup is slow! (O(n) when it could be O(1))
+        self.ecs
+            .entities
+            .clone()
+            .into_iter()
+            .position(|e| e == entity)
+            .map(|idx| Key { idx, entity })
+    }
+
     /// Read the data in the given component
     pub fn read<T: Component>(&self, key: Key) -> T {
         // TODO: Cache query lookups!

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -247,6 +247,9 @@ impl EngineIo {
     }
 
     /// Add a component to an entity
+    /// You may also use this to update existing component data, but it's better to write to the
+    /// query for large batches instead
+    #[track_caller]
     pub fn add_component<C: Component>(&mut self, entity: EntityId, data: &C) {
         let data = serialize(data).expect("Failed to serialize component data");
 

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -51,7 +51,7 @@ enum ClientOrServerState<ClientState, ServerState> {
 
 /// Basically main() for plugins; allows a struct implementing the [UserState](crate::plugin::UserState) trait to be the state and entry
 /// point for the plugin.
-/// 
+///
 /// Order matters to define which is the client state and which is the server state. Whatever goes first is the client state, and whatever goes second is the server state.
 ///
 /// The Syntax is `make_app_state(ClientState, ServerState)`, in that order.

--- a/engine_interface/src/stdout.rs
+++ b/engine_interface/src/stdout.rs
@@ -37,7 +37,6 @@ macro_rules! println {
     }};
 }
 
-
 #[macro_export]
 macro_rules! dbg {
     // NOTE: We cannot use `concat!` to make a static string as a format argument

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -52,7 +52,7 @@ impl UserState for ServerState {
 impl ServerState {
     fn startup(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
         for k in query.iter() {
-            io.remove_entity(k.entity());
+            io.remove_entity(k);
         }
 
         // Cube mesh

--- a/example_plugins/fluid-sim/src/lib.rs
+++ b/example_plugins/fluid-sim/src/lib.rs
@@ -48,7 +48,7 @@ impl UserState for ServerState {
 impl ServerState {
     fn init(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
         for key in query.iter() {
-            io.remove_entity(key.entity());
+            io.remove_entity(key);
         }
 
         // Fluid lines mesh

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -82,9 +82,9 @@ impl ServerState {
         for key in query.iter() {
             let SpinningCube(client_id) = query.read::<SpinningCube>(key);
             if conns.clients.contains(&client_id) {
-                client_to_entity.insert(client_id, key.entity());
+                client_to_entity.insert(client_id, key);
             } else {
-                io.remove_entity(key.entity());
+                io.remove_entity(key);
             }
         }
 

--- a/example_plugins/shader/src/lib.rs
+++ b/example_plugins/shader/src/lib.rs
@@ -87,7 +87,7 @@ impl ClientState {
     fn deleteme(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
         for key in query.iter() {
             let time = query.read::<RenderExtra>(key).0[0];
-            dbg!((time, key.entity()));
+            dbg!((time, key));
         }
     }
 }

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -28,14 +28,12 @@ impl UserState for ServerState {
 }
 
 impl ServerState {
-    fn update(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
+    fn update(&mut self, io: &mut EngineIo, _query: &mut QueryResult) {
         if let Some(ChangeColor { rgb }) = io.inbox_first() {
-            for key in query.iter() {
-                let mut extra = [0.; 4 * 4];
-                extra[..3].copy_from_slice(&rgb);
-                extra[3] = 1.;
-                io.add_component(key.entity(), &RenderExtra(extra));
-            }
+            let mut extra = [0.; 4 * 4];
+            extra[..3].copy_from_slice(&rgb);
+            extra[3] = 1.;
+            io.add_component(self.cube, &RenderExtra(extra));
         }
     }
 }


### PR DESCRIPTION
This PR simplifies the ECS interface a little bit and adds a feature. This change makes it so that systems can modify components corresponding to `EntityId`s from within the `QueryResult` (instead of relying on the `Key` datatype from `query.iter()`). Requires minimal changes to existing plugins (instead of `key.entity()` you can just use `key`). There may be a small performance penalty for this change when modifying many many entities, but this tradeoff could be optimized away in the future.