### PR TITLE
Use the lovely derive macros we have implemented!

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -262,6 +262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cimvr_derive_macros"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "cimvr_engine"
 version = "0.1.0"
 dependencies = [
@@ -280,6 +291,7 @@ name = "cimvr_engine_interface"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "cimvr_derive_macros",
  "log",
  "once_cell",
  "serde",
@@ -1872,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]

--- a/common/src/desktop.rs
+++ b/common/src/desktop.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 // TODO: Touchscreen support!
 
 /// Input events reported each frame
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Message, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[locality("Local")]
 pub struct InputEvents(pub Vec<InputEvent>);
 
 /// Basic input events
@@ -32,13 +33,6 @@ pub enum MouseEvent {
 pub enum WindowEvent {
     /// Window's size in pixels changed
     Resized { width: u32, height: u32 },
-}
-
-impl Message for InputEvents {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("InputEvents"),
-        locality: Locality::Local,
-    };
 }
 
 /// Keyboard events

--- a/common/src/gamepad.rs
+++ b/common/src/gamepad.rs
@@ -4,15 +4,9 @@ use cimvr_engine_interface::{pkg_namespace, prelude::*};
 use serde::{Deserialize, Serialize};
 
 /// State of each gamepad
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[locality("Local")]
 pub struct GamepadState(pub Vec<Gamepad>);
-
-impl Message for GamepadState {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("GamepadState"),
-        locality: Locality::Local,
-    };
-}
 
 /// Entire state of one game pad
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,16 +22,12 @@ pub mod vr;
 /// Represents a rotation, followed by a translation.
 /// Composable through the multiplication (`*`) operator.
 /// Features `From`/`Into` for `Isometry3<f32>`.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
+#[derive(Component, Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
 pub struct Transform {
     /// Position
     pub pos: Vec3,
     /// Orientation (Rotation)
     pub orient: Quat,
-}
-
-impl Component for Transform {
-    const ID: &'static str = pkg_namespace!("Transform");
 }
 
 impl Default for Transform {

--- a/common/src/render.rs
+++ b/common/src/render.rs
@@ -36,7 +36,7 @@ make_handle!(ShaderHandle);
 /// The Transform on the entity this is attached to will correspond to:
 /// * VR: The position and orientation of the floor
 /// * Desktop: The view matrix of the camera
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
+#[derive(Component, Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
 pub struct CameraComponent {
     /// Background color
     pub clear_color: [f32; 3],
@@ -77,7 +77,7 @@ pub struct Mesh {
 }
 
 /// Render component
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Component, Serialize, Deserialize, Default, Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Render {
     /// Id of the associated RenderData
     pub id: MeshHandle,
@@ -96,7 +96,7 @@ pub struct Render {
 }
 
 /// Extra render data per component
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq)]
+#[derive(Component, Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq)]
 pub struct RenderExtra(pub [f32; 4 * 4]);
 
 /// How to draw the given mesh
@@ -113,14 +113,6 @@ impl Default for Primitive {
     }
 }
 
-impl Component for Render {
-    const ID: &'static str = pkg_namespace!("Render");
-}
-
-impl Component for RenderExtra {
-    const ID: &'static str = pkg_namespace!("RenderExtra");
-}
-
 impl Message for UploadMesh {
     const CHANNEL: ChannelIdStatic = ChannelIdStatic {
         id: pkg_namespace!("RenderData"),
@@ -133,10 +125,6 @@ impl Message for ShaderSource {
         id: pkg_namespace!("ShaderData"),
         locality: Locality::Local,
     };
-}
-
-impl Component for CameraComponent {
-    const ID: &'static str = pkg_namespace!("CameraComponent");
 }
 
 impl Vertex {

--- a/common/src/render.rs
+++ b/common/src/render.rs
@@ -47,7 +47,8 @@ pub struct CameraComponent {
 }
 
 /// All information required to define a renderable mesh
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Message, Serialize, Deserialize, Debug, Clone)]
+#[locality("Local")]
 pub struct UploadMesh {
     /// Mesh data
     pub mesh: Mesh,
@@ -56,7 +57,8 @@ pub struct UploadMesh {
 }
 
 /// A complete description of a shader (sources)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Message, Serialize, Deserialize, Debug, Clone)]
+#[locality("Local")]
 pub struct ShaderSource {
     // TODO: Use SPIRV here? It's much more stable!
     /// Vertex shader source (GLSL)
@@ -111,20 +113,6 @@ impl Default for Primitive {
     fn default() -> Self {
         Self::Triangles
     }
-}
-
-impl Message for UploadMesh {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("RenderData"),
-        locality: Locality::Local,
-    };
-}
-
-impl Message for ShaderSource {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("ShaderData"),
-        locality: Locality::Local,
-    };
 }
 
 impl Vertex {

--- a/common/src/ui.rs
+++ b/common/src/ui.rs
@@ -34,14 +34,16 @@ pub enum State {
 }
 
 /// UI update message sent from plugins
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[locality("Local")]
 pub struct UiUpdate {
     pub id: UiHandle,
     pub state: Vec<State>,
 }
 
 /// UI request message sent to plugins
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[locality("Local")]
 pub struct UiRequest {
     pub id: UiHandle,
     pub op: UiOperation,
@@ -144,18 +146,4 @@ impl UiStateHelper {
             }
         }
     }
-}
-
-impl Message for UiRequest {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("UiRequest"),
-        locality: Locality::Local,
-    };
-}
-
-impl Message for UiUpdate {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("UiUpdate"),
-        locality: Locality::Local,
-    };
 }

--- a/common/src/vr.rs
+++ b/common/src/vr.rs
@@ -5,7 +5,8 @@ use cimvr_engine_interface::{pkg_namespace, prelude::*};
 use serde::{Deserialize, Serialize};
 
 /// VR update message
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Message, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[locality("Local")]
 pub struct VrUpdate {
     /// View for left eye (may lag behind view in shaders by a small duration!)
     pub view_left: Transform,
@@ -50,10 +51,3 @@ pub enum VrEvent {
     // TODO: Events from controllers!
 }
 */
-
-impl Message for VrUpdate {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("VrUpdate"),
-        locality: Locality::Local,
-    };
-}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -61,7 +61,7 @@ struct PluginState {
 }
 
 /// Marker of plugin ownership, by plugin index
-#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Component, Copy, Clone, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PluginIndex(usize);
 
 impl PluginState {
@@ -342,8 +342,4 @@ impl Engine {
         // Run PostInit stage
         self.dispatch_plugin(Stage::PostInit, i)
     }
-}
-
-impl Component for PluginIndex {
-    const ID: &'static str = pkg_namespace!("Owner");
 }

--- a/engine_interface/src/lib.rs
+++ b/engine_interface/src/lib.rs
@@ -10,6 +10,7 @@ pub mod plugin;
 use std::{cell::RefCell, collections::HashMap};
 mod component_validate_error;
 pub mod component_validation;
+use cimvr_derive_macros::Component;
 pub use component_validation::is_fixed_size;
 
 pub use log;
@@ -61,7 +62,7 @@ macro_rules! pkg_namespace {
 ///
 /// Client-side these are not saved to disk, but they are still useful for plugins maintaining
 /// local ECS data in between plugin reloads
-#[derive(Copy, Clone, Debug, Hash, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Component, Copy, Clone, Debug, Hash, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Saved;
 
 use ecs::Component;
@@ -69,10 +70,6 @@ use once_cell::sync::Lazy;
 use prelude::{ChannelIdStatic, ComponentId, Locality, Message};
 use serde::{Deserialize, Serialize};
 use serial::serialized_size;
-
-impl Component for Saved {
-    const ID: &'static str = pkg_namespace!("Saved");
-}
 
 // TODO: Use an integer of nanoseconds instead?
 /// Frame timing information, denotes time since last frame

--- a/engine_interface/src/lib.rs
+++ b/engine_interface/src/lib.rs
@@ -75,19 +75,13 @@ use serial::serialized_size;
 /// Frame timing information, denotes time since last frame
 /// Note that a frame consists of PreUpdate, Update, and PostUpdate. This
 /// time is captured before PreUpdate, and stays the same throughout.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Message, Serialize, Deserialize, Debug, Clone, Copy)]
+#[locality("Local")]
 pub struct FrameTime {
     /// Delta time, in seconds
     pub delta: f32,
     /// Time since engine start, in seconds
     pub time: f32,
-}
-
-impl Message for FrameTime {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("FrameTime"),
-        locality: Locality::Local,
-    };
 }
 
 /// Get the maximum size of this component

--- a/engine_interface/src/network.rs
+++ b/engine_interface/src/network.rs
@@ -22,16 +22,10 @@ pub struct Connection {
 }
 
 /// Message which lists currently connected clients. Available server-only
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Message, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[locality("Local")]
 pub struct Connections {
     pub clients: Vec<Connection>,
-}
-
-impl Message for Connections {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("Connections"),
-        locality: Locality::Local,
-    };
 }
 
 /// Connection request from client to server

--- a/engine_interface/src/network.rs
+++ b/engine_interface/src/network.rs
@@ -8,13 +8,9 @@ pub struct ClientId(pub u32);
 /// Component indicating the entity is forcibly copied from client to server
 ///
 /// Cannot be added to or removed from entities clientside!
-#[derive(Copy, Clone, Debug, Hash, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Component, Copy, Clone, Debug, Hash, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Synchronized;
 //pub struct Synchronized(Reliability);
-
-impl Component for Synchronized {
-    const ID: &'static str = pkg_namespace!("Synchronized");
-}
 
 /// Information about a connected client
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/example_plugins/channels/src/lib.rs
+++ b/example_plugins/channels/src/lib.rs
@@ -9,24 +9,16 @@ struct ServerState;
 
 make_app_state!(ClientState, ServerState);
 
+// It's important to make sure your package name is UNIQUE if you use this macro.
 /// Message datatype
-/// Implements Serialize and Deserialize, making it compatible with the Message trait.
-#[derive(Serialize, Deserialize, Debug)]
+/// Implements Serialize and Deserialize, making it compatible with the Message trait. We
+/// derive the Message trait, with locality "Remote" because we want this message sent
+/// server-side.
+#[derive(Message, Serialize, Deserialize, Debug)]
+#[locality("Remote")]
 struct MyMessage {
     a: i32,
     b: f32,
-}
-
-impl Message for MyMessage {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        // Here we define the universally unique name for this message.
-        // Note that this macro simply concatenates the package name with the name you provide.
-        // We could have written "channels_example/MyMessage" or even "jdasjdlfkjasdjfk" instead.
-        // It's important to make sure your package name is UNIQUE if you use this macro.
-        id: pkg_namespace!("MyMessage"),
-        // Sent to server
-        locality: Locality::Remote,
-    };
 }
 
 // Client code

--- a/example_plugins/chat/src/lib.rs
+++ b/example_plugins/chat/src/lib.rs
@@ -13,14 +13,16 @@ struct ServerState;
 make_app_state!(ClientState, ServerState);
 
 /// Server to client chat message datatype
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Message, Serialize, Deserialize, Debug)]
+#[locality("Remote")]
 struct ChatDownload {
     username: String,
     text: String,
 }
 
 /// Client to server chat message datatype
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Message, Serialize, Deserialize, Debug)]
+#[locality("Remote")]
 struct ChatUpload(String);
 
 /// Number of chat log messages
@@ -155,18 +157,4 @@ impl ServerState {
             }
         }
     }
-}
-
-impl Message for ChatDownload {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("ChatDownload"),
-        locality: Locality::Remote,
-    };
-}
-
-impl Message for ChatUpload {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("ChatUpload"),
-        locality: Locality::Remote,
-    };
 }

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -15,7 +15,7 @@ struct ClientState;
 
 make_app_state!(ClientState, ServerState);
 
-#[derive(Serialize, Deserialize, Default, Clone, Copy)]
+#[derive(Component, Serialize, Deserialize, Default, Clone, Copy)]
 pub struct MoveCube {
     pub r: f32,
 }
@@ -157,10 +157,6 @@ void main() {
         fragment_src,
         id: CUBE_SHADER,
     }
-}
-
-impl Component for MoveCube {
-    const ID: &'static str = pkg_namespace!("MoveCube");
 }
 
 // TODO: Add a PR to glam?

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -11,18 +11,10 @@ make_app_state!(ClientState, ServerState);
 
 /// Component datatype
 /// Implements Serialize and Deserialize, making it compatible with the Component trait.
-#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug)]
+#[derive(Component, Serialize, Deserialize, Default, Clone, Copy, Debug)]
 struct MyComponent {
     a: i32,
     b: f32,
-}
-
-impl Component for MyComponent {
-    // Here we define the universally unique name for this component.
-    // Note that this macro simply concatenates the package name with the name you provide.
-    // We could have written "channels_example/MyMessage" or even "jdasjdlfkjasdjfk" instead.
-    // It's important to make sure your package name is UNIQUE if you use this macro.
-    const ID: &'static str = pkg_namespace!("MyComponent");
 }
 
 // Server code

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -49,7 +49,7 @@ impl ClientState {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug)]
+#[derive(Component, Serialize, Deserialize, Default, Copy, Clone, Debug)]
 struct SpinningCube(ClientId);
 
 struct ServerState;
@@ -142,10 +142,6 @@ impl Message for AxisMessage {
         id: pkg_namespace!("AxisMessage"),
         locality: Locality::Remote,
     };
-}
-
-impl Component for SpinningCube {
-    const ID: &'static str = pkg_namespace!("ClientOwner");
 }
 
 pub fn from_euler_angles(roll: f32, pitch: f32, yaw: f32) -> Quat {

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 
 struct ClientState;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Message, Serialize, Deserialize, Debug)]
+#[locality("Remote")]
 struct AxisMessage {
     axis: f32,
 }
@@ -135,13 +136,6 @@ fn cube() -> Mesh {
     ];
 
     Mesh { vertices, indices }
-}
-
-impl Message for AxisMessage {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("AxisMessage"),
-        locality: Locality::Remote,
-    };
 }
 
 pub fn from_euler_angles(roll: f32, pitch: f32, yaw: f32) -> Quat {

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -181,14 +181,3 @@ fn cube() -> Mesh {
 
     Mesh { vertices, indices }
 }
-
-// impl Component for CubeFlag {
-//     const ID: &'static str = pkg_namespace!("Cube Flag");
-// }
-
-// impl Message for MoveCommand {
-//     const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-//         id: pkg_namespace!("MoveCommand"),
-//         locality: Locality::Remote,
-//     };
-// }

--- a/example_plugins/ui_example/src/lib.rs
+++ b/example_plugins/ui_example/src/lib.rs
@@ -8,14 +8,8 @@ use server::ServerState;
 
 make_app_state!(ClientState, ServerState);
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Message, Clone, Debug, Serialize, Deserialize)]
+#[locality("Remote")]
 pub struct ChangeColor {
     rgb: [f32; 3],
-}
-
-impl Message for ChangeColor {
-    const CHANNEL: ChannelIdStatic = ChannelIdStatic {
-        id: pkg_namespace!("ChangeColor"),
-        locality: Locality::Remote,
-    };
 }


### PR DESCRIPTION
Implements the derive macros for all the places where we previously manually implemented the `Component` and `Message` traits. No plugin changes required.