### PR TITLE
Multiple queries (alternate interface)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiple_queries"
+version = "0.1.0"
+dependencies = [
+ "cimvr_common",
+ "cimvr_engine_interface",
+ "serde",
+]
+
+[[package]]
 name = "notify"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "example_plugins/gamepad",
     "example_plugins/keyboard",
     "example_plugins/chat",
+    "example_plugins/multiple_queries",
 ]
 
 # Causes a build issue with OpenXR if included in workspace

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5568a4aa5ba8adf5175c5c460b030e27d8893412976cc37bef0e4fbc16cfbba"
+checksum = "fe21446ad43aa56417a767f3e2f3d7c4ca522904de1dd640529a76e9c5c3b33c"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6"
+checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "addr2line"
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -47,24 +47,24 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -74,13 +74,13 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -124,37 +124,37 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe233b960f12f8007e3db2d136e3cb1c291bfd7396e384ee76025fc1a3932b4"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -165,9 +165,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "calloop"
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -230,7 +230,7 @@ dependencies = [
  "glutin-openxr-opengl-helper",
  "log",
  "openxr",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "structopt",
 ]
 
@@ -252,7 +252,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -542,22 +542,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -622,7 +622,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "emath"
@@ -826,13 +826,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -862,6 +862,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "file-per-thread-logger"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,14 +882,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -890,7 +899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -920,13 +929,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -992,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1002,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1026,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6789d356476c3280a4e15365d23f62b4b4f1bcdac81fdd552f65807bce4666dd"
+checksum = "373b55d596e5a84fff61c559de54351a69f9ff481593ac78c35d9dc625df8d8f"
 dependencies = [
  "core-foundation",
  "io-kit-sys",
@@ -1036,7 +1045,7 @@ dependencies = [
  "libc",
  "libudev-sys",
  "log",
- "nix 0.25.1",
+ "nix 0.26.2",
  "uuid",
  "vec_map",
  "wasm-bindgen",
@@ -1106,7 +1115,7 @@ dependencies = [
  "once_cell",
  "osmesa-sys",
  "parking_lot",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "wayland-client",
  "wayland-egl",
  "winapi",
@@ -1214,6 +1223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -1286,34 +1301,35 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7789f7f3c9686f96164f5109d69152de759e76e284f736bd57661c6df5091919"
+checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
 dependencies = [
  "core-foundation-sys",
- "mach",
+ "mach2",
 ]
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys 0.42.0",
+ "rustix 0.37.13",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1367,18 +1383,18 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1423,9 +1439,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -1452,6 +1468,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -1482,6 +1504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,18 +1529,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix",
+ "rustix 0.37.13",
 ]
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -1519,15 +1550,6 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -1557,15 +1579,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.5"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1578,7 +1610,7 @@ dependencies = [
  "jni-sys",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
@@ -1614,7 +1646,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1652,6 +1684,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,9 +1703,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1669,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -1682,7 +1726,7 @@ dependencies = [
  "libc",
  "mio",
  "walkdir",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1691,29 +1735,29 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1739,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openxr"
@@ -1777,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5f3c7ca08b6879e7965fb25e24d1f5eeb32ea73f9ad99b3854778a38c57e93"
+checksum = "e25e9fb15717794fae58ab55c26e044103aad13186fbb625893f9a3bbcc24228"
 dependencies = [
  "ttf-parser",
 ]
@@ -1796,22 +1840,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"
@@ -1833,14 +1877,15 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "png"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
 dependencies = [
  "bitflags",
  "crc32fast",
+ "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -1851,13 +1896,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1869,7 +1913,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1886,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1915,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1963,18 +2007,15 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
-dependencies = [
- "cty",
-]
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -1982,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2026,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2037,28 +2078,42 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.36.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "e0af200a3324fa5bcd922e84e9b55a298ea9f431a489f01961acdebc6e908f25"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2105,22 +2160,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2164,6 +2219,12 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "slice-group-by"
@@ -2212,6 +2273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,14 +2305,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2254,15 +2332,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -2278,22 +2356,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2338,11 +2416,28 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2367,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf554b6e535f9a160b2ed4ea83f99000f21cbc0a693df26e258eaf2c226a151"
+checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
 
 [[package]]
 name = "typenum"
@@ -2394,9 +2489,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -2409,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -2438,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 
 [[package]]
 name = "vec_map"
@@ -2456,12 +2551,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -2473,9 +2567,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2483,24 +2577,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2508,22 +2602,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
@@ -2597,7 +2691,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.36.12",
  "serde",
  "sha2",
  "toml",
@@ -2614,7 +2708,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -2674,7 +2768,7 @@ checksum = "01b1192624694399f601de28db78975ed20fa859da8e048bf8250bd3b38d302b"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.36.12",
  "wasmtime-asm-macros",
  "windows-sys 0.45.0",
 ]
@@ -2712,7 +2806,7 @@ checksum = "17e35d335dd2461c631ba24d2326d993bd3a4bdb4b0217e5bda4f518ba0e29f3"
 dependencies = [
  "object",
  "once_cell",
- "rustix",
+ "rustix 0.36.12",
 ]
 
 [[package]]
@@ -2743,7 +2837,7 @@ dependencies = [
  "memoffset 0.8.0",
  "paste",
  "rand",
- "rustix",
+ "rustix 0.36.12",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -2776,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "55.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4984d3e1406571f4930ba5cf79bd70f75f41d0e87e17506e0bd19b0e5d085f05"
+checksum = "6b54185c051d7bbe23757d50fe575880a2426a2f06d2e9f6a10fd9a4a42920c0"
 dependencies = [
  "leb128",
  "memchr",
@@ -2788,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2b53f4da14db05d32e70e9c617abdf6620c575bd5dd972b7400037b4df2091"
+checksum = "56681922808216ab86d96bb750f70d500b5a7800e41564290fd46bb773581299"
 dependencies = [
  "wast",
 ]
@@ -2880,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2921,17 +3015,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.43.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2953,12 +3041,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
 ]
 
@@ -2968,7 +3056,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2977,13 +3074,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2991,6 +3103,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3005,6 +3123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3139,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3029,6 +3159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,10 +3177,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3057,6 +3205,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"
@@ -3080,7 +3234,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle 0.4.3",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
@@ -3089,6 +3243,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.36.1",
  "x11-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3117,12 +3280,12 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.20.1"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1536d6965a5d4e573c7ef73a2c15ebcd0b2de3347bdf526c34c297c00ac40f0"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
 dependencies = [
- "lazy_static",
  "libc",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -3162,10 +3325,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.4+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,7 +6,9 @@ extern crate openxr as xr;
 use anyhow::{bail, Context, Result};
 use cimvr_common::glam::Mat4;
 use cimvr_engine::hotload::Hotloader;
-use cimvr_engine::interface::prelude::{Access, ConnectionRequest, QueryComponent, Synchronized};
+use cimvr_engine::interface::prelude::{
+    Access, ConnectionRequest, Query, Synchronized,
+};
 use cimvr_engine::interface::serial::{deserialize, serialize};
 use cimvr_engine::network::{
     length_delimit_message, AsyncBufferedReceiver, ClientToServer, ReadState, ServerToClient,
@@ -157,7 +159,7 @@ impl Client {
                         self.engine.broadcast_local(msg);
                     }
                     self.engine.ecs().import(
-                        &[QueryComponent::new::<Synchronized>(Access::Read)],
+                        &Query::new("Synchronized").intersect::<Synchronized>(Access::Write),
                         recv.ecs,
                     );
                 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -159,7 +159,7 @@ impl Client {
                         self.engine.broadcast_local(msg);
                     }
                     self.engine.ecs().import(
-                        &Query::new("Synchronized").intersect::<Synchronized>(Access::Write),
+                        &Query::new().intersect::<Synchronized>(Access::Write),
                         recv.ecs,
                     );
                 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,9 +6,7 @@ extern crate openxr as xr;
 use anyhow::{bail, Context, Result};
 use cimvr_common::glam::Mat4;
 use cimvr_engine::hotload::Hotloader;
-use cimvr_engine::interface::prelude::{
-    Access, ConnectionRequest, Query, Synchronized,
-};
+use cimvr_engine::interface::prelude::{Access, ConnectionRequest, Query, Synchronized};
 use cimvr_engine::interface::serial::{deserialize, serialize};
 use cimvr_engine::network::{
     length_delimit_message, AsyncBufferedReceiver, ClientToServer, ReadState, ServerToClient,

--- a/client/src/render.rs
+++ b/client/src/render.rs
@@ -4,10 +4,7 @@ use anyhow::Result;
 use cimvr_common::glam::Mat4;
 use cimvr_common::{render::*, Transform};
 use cimvr_engine::interface::prelude::*;
-use cimvr_engine::{
-    interface::{pkg_namespace},
-    Engine,
-};
+use cimvr_engine::{interface::pkg_namespace, Engine};
 use gl::HasContext;
 use glow::NativeUniformLocation;
 

--- a/client/src/render.rs
+++ b/client/src/render.rs
@@ -85,7 +85,7 @@ impl RenderPlugin {
         let camera_entity = match engine
             .ecs()
             .query(
-                &Query::new("Camera")
+                &Query::new()
                     .intersect::<CameraComponent>(Access::Read)
                     .intersect::<Transform>(Access::Read),
             )
@@ -109,7 +109,7 @@ impl RenderPlugin {
 
         // Prepare data
         let entities = engine.ecs().query(
-            &Query::new("RenderObjects")
+            &Query::new()
                 .intersect::<Render>(Access::Read)
                 .intersect::<Transform>(Access::Read),
         );

--- a/client/src/render.rs
+++ b/client/src/render.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use cimvr_common::glam::Mat4;
 use cimvr_common::{render::*, Transform};
 use cimvr_engine::interface::prelude::*;
-use cimvr_engine::{interface::{pkg_namespace, component_id}, Engine};
+use cimvr_engine::{
+    interface::{pkg_namespace},
+    Engine,
+};
 use gl::HasContext;
 use glow::NativeUniformLocation;
 
@@ -63,12 +66,7 @@ impl RenderPlugin {
     }
 
     /// Draw a frame, prepending camera transform to the given view
-    pub fn frame(
-        &mut self,
-        engine: &mut Engine,
-        vr_view: Mat4,
-        camera_idx: usize,
-    ) -> Result<()> {
+    pub fn frame(&mut self, engine: &mut Engine, vr_view: Mat4, camera_idx: usize) -> Result<()> {
         // Upload render data
         for msg in engine.inbox::<UploadMesh>() {
             if let Err(e) = self.rdr.upload_render_data(&self.gl, &msg) {
@@ -86,7 +84,13 @@ impl RenderPlugin {
         // Find camera, if any
         let camera_entity = match engine
             .ecs()
-            .find(&[component_id::<CameraComponent>(), component_id::<Transform>()])
+            .query(
+                &Query::new("Camera")
+                    .intersect::<CameraComponent>(Access::Read)
+                    .intersect::<Transform>(Access::Read),
+            )
+            .into_iter()
+            .next()
         {
             Some(c) => c,
             None => {
@@ -104,10 +108,11 @@ impl RenderPlugin {
         self.rdr.start_frame(&self.gl, camera_comp.clear_color)?;
 
         // Prepare data
-        let entities = engine.ecs().query(&[
-            QueryComponent::new::<Render>(Access::Read),
-            QueryComponent::new::<Transform>(Access::Read),
-        ]);
+        let entities = engine.ecs().query(
+            &Query::new("RenderObjects")
+                .intersect::<Render>(Access::Read)
+                .intersect::<Transform>(Access::Read),
+        );
 
         for entity in entities {
             let transf = engine.ecs().get::<Transform>(entity).unwrap();
@@ -277,13 +282,13 @@ impl GpuShader {
             gl.uniform_matrix_4_f32_slice(
                 gl.get_uniform_location(self.program, "view").as_ref(),
                 false,
-                &view.to_cols_array()
+                &view.to_cols_array(),
             );
 
             gl.uniform_matrix_4_f32_slice(
                 gl.get_uniform_location(self.program, "proj").as_ref(),
                 false,
-                &proj.to_cols_array()
+                &proj.to_cols_array(),
             );
         }
     }
@@ -327,8 +332,8 @@ fn compile_glsl_program(gl: &gl::Context, sources: &[(u32, &str)]) -> Result<gl:
 
             if !gl.get_shader_compile_status(shader) {
                 return Err(format_err!(
-                        "OpenGL compile shader: {}",
-                        gl.get_shader_info_log(shader)
+                    "OpenGL compile shader: {}",
+                    gl.get_shader_info_log(shader)
                 ));
             }
 
@@ -341,8 +346,8 @@ fn compile_glsl_program(gl: &gl::Context, sources: &[(u32, &str)]) -> Result<gl:
 
         if !gl.get_program_link_status(program) {
             return Err(format_err!(
-                    "OpenGL link shader: {}",
-                    gl.get_program_info_log(program)
+                "OpenGL link shader: {}",
+                gl.get_program_info_log(program)
             ));
         }
 

--- a/client/src/vr.rs
+++ b/client/src/vr.rs
@@ -2,17 +2,19 @@ use crate::desktop_input::DesktopInputHandler;
 use crate::{Client, Opt};
 use anyhow::{format_err, Result};
 use cimvr_common::glam::{Quat, Vec3};
-use cimvr_common::vr::{VrFov, VrUpdate, HeadsetState, ViewState, ControllerState, ControllerEvent};
+use cimvr_common::vr::{
+    ControllerEvent, ControllerState, HeadsetState, ViewState, VrFov, VrUpdate,
+};
 use cimvr_common::Transform;
 use cimvr_engine::interface::system::Stage;
 use gl::HasContext;
+use glutin::event::{Event, WindowEvent};
 use glutin::event_loop::ControlFlow;
 use glutin::event_loop::EventLoop;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use xr::View;
-use glutin::event::{Event, WindowEvent};
 
 const VR_DEPTH_FORMAT: u32 = gl::DEPTH_COMPONENT24;
 
@@ -65,7 +67,11 @@ struct MainLoop {
 }
 
 impl MainLoop {
-    pub fn new(plugins: Vec<PathBuf>, connect: SocketAddr, username: String) -> Result<(Self, EventLoop<()>)> {
+    pub fn new(
+        plugins: Vec<PathBuf>,
+        connect: SocketAddr,
+        username: String,
+    ) -> Result<(Self, EventLoop<()>)> {
         // Load OpenXR from platform-specific location
         #[cfg(target_os = "linux")]
         let entry = unsafe { xr::Entry::load()? };
@@ -512,19 +518,14 @@ impl PluginVrInterfacing {
         let aim_right_action =
             action_set.create_action::<xr::Posef>("aim_right", "aim_right", &[])?;
 
-        let trigger_left =
-            action_set.create_action::<bool>("trigger_left", "trigger_left", &[])?;
+        let trigger_left = action_set.create_action::<bool>("trigger_left", "trigger_left", &[])?;
 
-        let menu_left =
-            action_set.create_action::<bool>("menu_left", "menu_left", &[])?;
+        let menu_left = action_set.create_action::<bool>("menu_left", "menu_left", &[])?;
 
         let trigger_right =
             action_set.create_action::<bool>("trigger_right", "trigger_right", &[])?;
 
-        let menu_right =
-            action_set.create_action::<bool>("menu_right", "menu_right", &[])?;
-
-
+        let menu_right = action_set.create_action::<bool>("menu_right", "menu_right", &[])?;
 
         xr_instance
             .suggest_interaction_profile_bindings(
@@ -683,7 +684,6 @@ impl PluginVrInterfacing {
         if menu_left.changed_since_last_sync {
             left_events.push(ControllerEvent::Menu(menu_left.current_state.into()));
         }
-
 
         let mut right_events = vec![];
         let trigger_right = self.trigger_right.state(xr_session, xr::Path::NULL)?;

--- a/common/src/utils/camera.rs
+++ b/common/src/utils/camera.rs
@@ -1,9 +1,4 @@
-use glam::{
-    Mat4,
-    Vec3,
-    Quat,
-    EulerRot,
-};
+use glam::{EulerRot, Mat4, Quat, Vec3};
 
 use crate::{
     desktop::{InputEvent, WindowEvent},
@@ -114,8 +109,7 @@ pub struct Orthographic {
     proj: [Mat4; 2],
 }
 
-
-impl Default for Orthographic{
+impl Default for Orthographic {
     fn default() -> Self {
         Self {
             screen_size: (1920, 1080),
@@ -130,11 +124,14 @@ impl Default for Orthographic{
     }
 }
 
-impl Orthographic{
+impl Orthographic {
     pub fn update_proj(&mut self, mut width: f32, mut height: f32, input: &InputEvent) {
-        
         // Check if the screen size changes
-        if let InputEvent::Window(WindowEvent::Resized { width: screen_width, height: screen_height }) = input {
+        if let InputEvent::Window(WindowEvent::Resized {
+            width: screen_width,
+            height: screen_height,
+        }) = input
+        {
             self.screen_size = (*screen_width, *screen_height);
         }
 
@@ -142,21 +139,21 @@ impl Orthographic{
         let aspect_ratio = self.screen_size.0 as f32 / self.screen_size.1 as f32;
 
         // If the world aspect ratio is biggeer or equal to the screen size, then update the height that matches the screen aspect ratio
-        if width / height >= aspect_ratio as f32{
+        if width / height >= aspect_ratio as f32 {
             height = width / aspect_ratio as f32;
         }
         // Otherwise, update the width screen aspect ratio oto the world aspect ratio
-        else{
+        else {
             width = height * aspect_ratio as f32;
         }
-        
+
         // Get the correct values for setting up the orthographic arguments
         self.left = -width / 2.;
         self.right = width / 2.;
         self.bottom = -height / 2.;
         self.top = height / 2.;
 
-        // Recreate the new projection matrix based on the updated screen size        
+        // Recreate the new projection matrix based on the updated screen size
         let new_proj = Mat4::orthographic_rh_gl(
             self.left,
             self.right,
@@ -177,17 +174,30 @@ impl Orthographic{
     }
 
     pub fn camera_on_positive_z_axis(&self) -> Transform {
-    // This camera control is for 2D arcade games that are played on a flat screen: z-axis is to us
+        // This camera control is for 2D arcade games that are played on a flat screen: z-axis is to us
         Transform {
             pos: Vec3::new(0., 0., 5.),
             orient: Default::default(),
         }
     }
 
-    pub fn camera_on_custom_axis(&self, pos_x: f32, pos_y: f32, pos_z: f32, degree_x: f32, degree_y: f32, degree_z: f32) -> Transform {
+    pub fn camera_on_custom_axis(
+        &self,
+        pos_x: f32,
+        pos_y: f32,
+        pos_z: f32,
+        degree_x: f32,
+        degree_y: f32,
+        degree_z: f32,
+    ) -> Transform {
         Transform {
             pos: Vec3::new(pos_x, pos_y, pos_z),
-            orient: Quat::from_euler(EulerRot::XYZ, degree_x.to_radians(), degree_y.to_radians(), degree_z.to_radians()),
+            orient: Quat::from_euler(
+                EulerRot::XYZ,
+                degree_x.to_radians(),
+                degree_y.to_radians(),
+                degree_z.to_radians(),
+            ),
         }
     }
 }

--- a/engine/src/ecs.rs
+++ b/engine/src/ecs.rs
@@ -33,9 +33,9 @@ impl Ecs {
     /// Returns the list of relevant entities
     /// Empty queries panic.
     /// If a component requested does not exist, panic.
-    pub fn query(&mut self, query: &[QueryComponent]) -> HashSet<EntityId> {
+    pub fn query(&mut self, query: &Query) -> HashSet<EntityId> {
         //let (init, rest) = q.split_first().expect("Empty query");
-        let Some((init, rest)) = query.split_first() else { return HashSet::new() };
+        let Some((init, rest)) = query.intersect.split_first() else { return HashSet::new() };
 
         // Initialize to the entities in the first term..
         // TODO: Pick smallest?
@@ -58,6 +58,7 @@ impl Ecs {
         entities
     }
 
+    /*
     /// Returns a semi-random entity matching the given query, if any
     pub fn find(&mut self, query: &[ComponentId]) -> Option<EntityId> {
         // TODO: Optimize me
@@ -71,6 +72,7 @@ impl Ecs {
 
         self.query(&query).drain().next()
     }
+    */
 
     /// Import an entity ID from elsewhere
     pub fn import_entity(&mut self, id: EntityId) {
@@ -238,7 +240,7 @@ impl Ecs {
     }
     */
 
-    pub fn export(&mut self, query: &[QueryComponent]) -> EcsMap {
+    pub fn export(&mut self, query: &Query) -> EcsMap {
         let entities: Vec<EntityId> = self.query(query).into_iter().collect();
 
         let mut exp = EcsMap::new();
@@ -254,7 +256,7 @@ impl Ecs {
         exp
     }
 
-    pub fn import(&mut self, query: &[QueryComponent], imported: EcsMap) {
+    pub fn import(&mut self, query: &Query, imported: EcsMap) {
         // Remove existing entities in the given query
         let entities: Vec<EntityId> = self.query(query).into_iter().collect();
         for id in entities {
@@ -279,7 +281,7 @@ pub fn query_ecs_data(ecs: &mut Ecs, queries: &HashMap<String, Query>) -> Result
     for (_, query) in queries {
         let entities = ecs.query(query).into_iter().collect::<Vec<_>>();
         for &entity in &entities {
-            for query_component in query {
+            for query_component in &query.intersect {
                 if let Some(data) = ecs.get_raw(entity, &query_component.component) {
                     map.entry(query_component.component.clone())
                         .or_default()

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -326,7 +326,7 @@ impl Engine {
         // Delete all unsaved entities from that plugin
         let indices = self
             .ecs
-            .query(&Query::new("PluginIndex").intersect::<PluginIndex>(Access::Read));
+            .query(&Query::new().intersect::<PluginIndex>(Access::Read));
         for ent in indices {
             if let Some(PluginIndex(idx)) = self.ecs().get::<PluginIndex>(ent) {
                 // Only those from the plugin that have no Saved component

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -206,7 +206,7 @@ impl Engine {
             }
 
             // Query ECS
-            let ecs_data = query_ecs_data(&mut self.ecs, &system.query).context("ECS query")?;
+            let ecs_data = query_ecs_data(&mut self.ecs, &system.queries).context("ECS query")?;
 
             // Write input data
             let recv_buf = ReceiveBuf {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -326,7 +326,7 @@ impl Engine {
         // Delete all unsaved entities from that plugin
         let indices = self
             .ecs
-            .query(&[QueryComponent::new::<PluginIndex>(Access::Read)]);
+            .query(&Query::new("PluginIndex").intersect::<PluginIndex>(Access::Read));
         for ent in indices {
             if let Some(PluginIndex(idx)) = self.ecs().get::<PluginIndex>(ent) {
                 // Only those from the plugin that have no Saved component

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -94,12 +94,13 @@ impl QueryResult {
     }
 
     /// Iterate through query entities
+    #[track_caller]
     pub fn iter(&self, name: &'static str) -> impl Iterator<Item = EntityId> {
-        let query = &self.query[name];
+        let query = &self.query.get(name).expect("Did not recognize this query name");
         let (initial, xs) = query
             .intersect
             .split_first()
-            .expect("No components in components");
+            .expect("No components");
 
         let tmp = HashMap::new();
         self.ecs

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -95,11 +95,11 @@ impl QueryResult {
     /// Iterate through query entities
     #[track_caller]
     pub fn iter(&self, name: &'static str) -> impl Iterator<Item = EntityId> {
-        let query = &self.query.get(name).expect("Did not recognize this query name");
-        let (initial, xs) = query
-            .intersect
-            .split_first()
-            .expect("No components");
+        let query = &self
+            .query
+            .get(name)
+            .expect("Did not recognize this query name");
+        let (initial, xs) = query.intersect.split_first().expect("No components");
 
         let tmp = HashMap::new();
         self.ecs

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -90,7 +90,7 @@ impl QueryResult {
     }
 
     /// Iterate through query entities
-    pub fn iter(&self, name: &'static str) -> impl Iterator<Item = EntityId> + '_ {
+    pub fn iter(&self, name: &'static str) -> impl Iterator<Item = EntityId> {
         let query = &self.query[name];
         let (initial, xs) = query.split_first().expect("No components in components");
 
@@ -101,6 +101,8 @@ impl QueryResult {
                     .all(|q| self.ecs[&q.component].contains_key(&entity_id))
             })
             .copied()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     /*

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -201,11 +201,17 @@ pub fn check_component_data_size(component_size: u16, size: usize) {
 }
 
 impl Query {
+    /// Creates a new Query, assigning the label `name`.
+    /// This name is used for both indexing, and for 
     pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            ..Default::default()
-        }
+        Self::default().rename(name)
+    }
+
+    /// Renames this query. Useful in situations where you do not control the construction of the
+    /// original query, e.g. from a library.
+    pub fn rename(mut self, name: &str) -> Self {
+        self.name = name.to_string();
+        self
     }
 
     /// Require this component to be present for each entity returned by this query.

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -94,11 +94,16 @@ impl QueryResult {
         let query = &self.query[name];
         let (initial, xs) = query.split_first().expect("No components in components");
 
-        self.ecs[&initial.component]
+        let tmp = HashMap::new();
+        self.ecs
+            .get(&initial.component)
+            .unwrap_or_else(|| &tmp)
             .keys()
             .filter(|entity_id| {
-                xs.iter()
-                    .all(|q| self.ecs[&q.component].contains_key(&entity_id))
+                xs.iter().all(|q| match self.ecs.get(&q.component) {
+                    Some(c) => c.contains_key(&entity_id),
+                    None => false,
+                })
             })
             .copied()
             .collect::<Vec<_>>()

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -157,7 +157,7 @@ impl QueryResult {
             .expect("Wrote to non-queried component id")
             .get_mut(&entity)
             .expect("Wrote to non-extant entity");
-        w[..data.len()].copy_from_slice(&data);
+        *w = data.clone();
 
         // Write host command
         self.commands

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -2,12 +2,12 @@
 //!
 //!
 
-use std::ops::Range;
+use std::collections::HashMap;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    component_id, component_size_cached,
+    component_id,
     serial::{deserialize, serialize, EcsData},
 };
 
@@ -77,11 +77,11 @@ pub struct QueryResult {
     /// ECS data from host
     ecs: EcsData,
     /// The original query, for reference
-    query: Query,
+    query: HashMap<String, Query>,
 }
 
 impl QueryResult {
-    pub(crate) fn new(ecs: EcsData, query: Query) -> Self {
+    pub(crate) fn new(ecs: EcsData, query: HashMap<String, Query>) -> Self {
         Self {
             commands: vec![],
             ecs,
@@ -90,10 +90,20 @@ impl QueryResult {
     }
 
     /// Iterate through query entities
-    pub fn iter(&self) -> impl Iterator<Item = EntityId> {
-        self.ecs.entities.clone().into_iter()
+    pub fn iter(&self, name: &'static str) -> impl Iterator<Item = EntityId> + '_ {
+        let query = &self.query[name];
+        let (initial, xs) = query.split_first().expect("No components in components");
+
+        self.ecs[&initial.component]
+            .keys()
+            .filter(|entity_id| {
+                xs.iter()
+                    .all(|q| self.ecs[&q.component].contains_key(&entity_id))
+            })
+            .copied()
     }
 
+    /*
     /// Get the index of the given entity id
     #[track_caller]
     fn get_entity_index(&self, entity: EntityId) -> usize {
@@ -124,30 +134,30 @@ impl QueryResult {
 
         (component_idx, begin..end)
     }
+    */
 
     /// Read the data in the given component
     #[track_caller]
-    pub fn read<T: Component>(&self, entity: EntityId) -> T {
+    pub fn read<C: Component>(&self, entity: EntityId) -> C {
         // TODO: Cache query lookups!
-        let (component_idx, range) = self.indices::<T>(entity);
-        let dense = &self.ecs.components[component_idx];
-        deserialize(&dense[range]).expect("Failed to deserialize component for reading")
+        let r = &self.ecs[&component_id::<C>()][&entity];
+        deserialize(r.as_slice()).expect("Failed to deserialize component for reading")
     }
 
     /// Write the given data to the component
     #[track_caller]
     pub fn write<C: Component>(&mut self, entity: EntityId, component: &C) {
-        let entity_idx = self.get_entity_index(entity);
-        let entity = self.ecs.entities[entity_idx];
-        // Serialize data
-        // TODO: Never allocate in hot loops!
         let data = serialize(component).expect("Failed to serialize component for writing");
 
         // Write back to ECS storage for possible later modification. This is never read by the
-        // host, but MAY be read by us!
-        let (component_idx, range) = self.indices::<C>(entity);
-        let dense = &mut self.ecs.components[component_idx];
-        dense[range].copy_from_slice(&data);
+        // host (for now), but MAY be read by the plugin!
+        let w = self
+            .ecs
+            .get_mut(&component_id::<C>())
+            .expect("Wrote to non-queried component id")
+            .get_mut(&entity)
+            .expect("Wrote to non-extant entity");
+        w[..data.len()].copy_from_slice(&data);
 
         // Write host command
         self.commands

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -202,7 +202,7 @@ pub fn check_component_data_size(component_size: u16, size: usize) {
 
 impl Query {
     /// Creates a new Query, assigning the label `name`.
-    /// This name is used for both indexing, and for 
+    /// This name is used for both indexing, and for
     pub fn new(name: &str) -> Self {
         Self::default().rename(name)
     }

--- a/engine_interface/src/ecs.rs
+++ b/engine_interface/src/ecs.rs
@@ -23,7 +23,6 @@ pub struct QueryComponent {
 /// A description of an ECS query
 #[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Query {
-    pub name: String,
     pub intersect: Vec<QueryComponent>,
 }
 
@@ -204,15 +203,8 @@ pub fn check_component_data_size(component_size: u16, size: usize) {
 impl Query {
     /// Creates a new Query, assigning the label `name`.
     /// This name is used for both indexing, and for
-    pub fn new(name: &str) -> Self {
-        Self::default().rename(name)
-    }
-
-    /// Renames this query. Useful in situations where you do not control the construction of the
-    /// original query, e.g. from a library.
-    pub fn rename(mut self, name: &str) -> Self {
-        self.name = name.to_string();
-        self
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Require this component to be present for each entity returned by this query.

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -166,11 +166,6 @@ pub struct SystemBuilder<'sched, U> {
     callback: Callback<U>,
 }
 
-pub struct QueryBuilder<'sched, U> {
-    sys: SystemBuilder<'sched, U>,
-    name: String,
-}
-
 impl<'a, U> SystemBuilder<'a, U> {
     /// Run the system during the specified Stage
     pub fn stage(mut self, stage: Stage) -> Self {
@@ -179,11 +174,9 @@ impl<'a, U> SystemBuilder<'a, U> {
     }
 
     /// Query the given component and provide an access level to it.
-    pub fn query(self, name: &'static str) -> QueryBuilder<'a, U> {
-        QueryBuilder {
-            sys: self,
-            name: name.to_string(),
-        }
+    pub fn query(mut self, query: Query) -> Self {
+        self.desc.queries.insert(query.name.clone(), query);
+        self
     }
 
     /// Subscribe to the given channel by telling it which message type you want.
@@ -196,24 +189,6 @@ impl<'a, U> SystemBuilder<'a, U> {
     pub fn build(self) {
         self.sched.systems.push(self.desc);
         self.sched.callbacks.push(self.callback);
-    }
-}
-
-impl<'a, U> QueryBuilder<'a, U> {
-    pub fn intersect<T: Component>(mut self, access: Access) -> Self {
-        let query = self
-            .sys
-            .desc
-            .queries
-            .entry(self.name.to_string())
-            .or_insert(Query::new());
-
-        query.push(QueryComponent::new::<T>(access));
-        self
-    }
-
-    pub fn qcommit(self) -> SystemBuilder<'a, U> {
-        self.sys
     }
 }
 

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -174,8 +174,8 @@ impl<'a, U> SystemBuilder<'a, U> {
     }
 
     /// Query the given component and provide an access level to it.
-    pub fn query(mut self, query: Query) -> Self {
-        self.desc.queries.insert(query.name.clone(), query);
+    pub fn query(mut self, name: &'static str, query: Query) -> Self {
+        self.desc.queries.insert(name.to_string(), query);
         self
     }
 

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -181,7 +181,7 @@ impl<U> SystemBuilder<'_, U> {
     pub fn query<T: Component>(&mut self, name: &'static str) -> QueryBuilder<'_> {
         let query = self
             .desc
-            .query
+            .queries
             .entry(name.to_string())
             .or_insert(Query::new());
         QueryBuilder { query }
@@ -213,7 +213,7 @@ impl<U: UserState> PluginState<U> {
         let system = self.sched.callbacks[system_idx];
 
         // Get query results
-        let query = self.sched.systems[system_idx].query.clone();
+        let query = self.sched.systems[system_idx].queries.clone();
         let mut query_result = QueryResult::new(ecs, query);
 
         // Run the user's system

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -212,7 +212,7 @@ impl<'a, U> QueryBuilder<'a, U> {
         self
     }
 
-    pub fn finish(self) -> SystemBuilder<'a, U> {
+    pub fn qcommit(self) -> SystemBuilder<'a, U> {
         self.sys
     }
 }

--- a/engine_interface/src/plugin.rs
+++ b/engine_interface/src/plugin.rs
@@ -166,11 +166,12 @@ pub struct SystemBuilder<'sched, U> {
     callback: Callback<U>,
 }
 
-pub struct QueryBuilder<'sysbuilder> {
-    query: &'sysbuilder mut Query,
+pub struct QueryBuilder<'sched, U> {
+    sys: SystemBuilder<'sched, U>,
+    name: String,
 }
 
-impl<U> SystemBuilder<'_, U> {
+impl<'a, U> SystemBuilder<'a, U> {
     /// Run the system during the specified Stage
     pub fn stage(mut self, stage: Stage) -> Self {
         self.desc.stage = stage;
@@ -178,13 +179,11 @@ impl<U> SystemBuilder<'_, U> {
     }
 
     /// Query the given component and provide an access level to it.
-    pub fn query<T: Component>(&mut self, name: &'static str) -> QueryBuilder<'_> {
-        let query = self
-            .desc
-            .queries
-            .entry(name.to_string())
-            .or_insert(Query::new());
-        QueryBuilder { query }
+    pub fn query(self, name: &'static str) -> QueryBuilder<'a, U> {
+        QueryBuilder {
+            sys: self,
+            name: name.to_string(),
+        }
     }
 
     /// Subscribe to the given channel by telling it which message type you want.
@@ -200,10 +199,21 @@ impl<U> SystemBuilder<'_, U> {
     }
 }
 
-impl QueryBuilder<'_> {
-    pub fn intersect<T: Component>(self, access: Access) -> Self {
-        self.query.push(QueryComponent::new::<T>(access));
+impl<'a, U> QueryBuilder<'a, U> {
+    pub fn intersect<T: Component>(mut self, access: Access) -> Self {
+        let query = self
+            .sys
+            .desc
+            .queries
+            .entry(self.name.to_string())
+            .or_insert(Query::new());
+
+        query.push(QueryComponent::new::<T>(access));
         self
+    }
+
+    pub fn finish(self) -> SystemBuilder<'a, U> {
+        self.sys
     }
 }
 

--- a/engine_interface/src/serial.rs
+++ b/engine_interface/src/serial.rs
@@ -1,5 +1,6 @@
 //! Types used for communication with the engine
 use std::{
+    collections::HashMap,
     fmt::Debug,
     io::{Read, Write},
 };
@@ -36,13 +37,7 @@ pub fn deserialize<R: Read, T: DeserializeOwned>(r: R) -> bincode::Result<T> {
 // (TODO: Make this just a header containing references to a dense buffer
 /// Plugin-local ECS data
 /// Represents the data returned by a query
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct EcsData {
-    /// Entity IDs aligned with components
-    pub entities: Vec<EntityId>,
-    /// Component data SoA, with components in the same order as the query terms
-    pub components: Vec<Vec<u8>>,
-}
+pub type EcsData = HashMap<ComponentId, HashMap<EntityId, Vec<u8>>>;
 
 /// Data transferred from Host to Plugin
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -55,10 +50,6 @@ pub struct ReceiveBuf {
     pub inbox: Inbox,
     /// True if plugin is server-side
     pub is_server: bool,
-    /*
-    /// Message buffers, in the same order as the subscribed channels
-    pub messages: Vec<Vec<Message>>,
-    */
 }
 
 /// Data transferred from Plugin to Host

--- a/engine_interface/src/system.rs
+++ b/engine_interface/src/system.rs
@@ -12,7 +12,7 @@ pub struct SystemDescriptor {
     /// Channels this system subscribes to
     pub subscriptions: Vec<ChannelId>,
     /// Component queries
-    pub query: HashMap<String, Query>,
+    pub queries: HashMap<String, Query>,
 }
 
 /// This flag indicates which stage the plugin is to be executed **after**.
@@ -40,7 +40,7 @@ impl Default for SystemDescriptor {
         Self {
             stage: Stage::Update,
             subscriptions: vec![],
-            query: Default::default(),
+            queries: Default::default(),
         }
     }
 }

--- a/engine_interface/src/system.rs
+++ b/engine_interface/src/system.rs
@@ -1,4 +1,6 @@
 //! Types used for communication with the engine
+use std::collections::HashMap;
+
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +12,7 @@ pub struct SystemDescriptor {
     /// Channels this system subscribes to
     pub subscriptions: Vec<ChannelId>,
     /// Component queries
-    pub query: Query,
+    pub query: HashMap<String, Query>,
 }
 
 /// This flag indicates which stage the plugin is to be executed **after**.
@@ -38,7 +40,7 @@ impl Default for SystemDescriptor {
         Self {
             stage: Stage::Update,
             subscriptions: vec![],
-            query: vec![],
+            query: Default::default(),
         }
     }
 }

--- a/example_plugins/camera/src/lib.rs
+++ b/example_plugins/camera/src/lib.rs
@@ -46,8 +46,8 @@ impl UserState for Camera {
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
             .subscribe::<VrUpdate>()
-            .query(
-                Query::new("Camera")
+            .query("Camera",
+                Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<CameraComponent>(Access::Write),
             )

--- a/example_plugins/camera/src/lib.rs
+++ b/example_plugins/camera/src/lib.rs
@@ -49,7 +49,7 @@ impl UserState for Camera {
             .query("Camera")
             .intersect::<Transform>(Access::Write)
             .intersect::<CameraComponent>(Access::Write)
-            .finish()
+            .qcommit()
             .build();
 
         let left_hand = io

--- a/example_plugins/camera/src/lib.rs
+++ b/example_plugins/camera/src/lib.rs
@@ -46,8 +46,10 @@ impl UserState for Camera {
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
             .subscribe::<VrUpdate>()
-            .query::<Transform>(Access::Write)
-            .query::<CameraComponent>(Access::Write)
+            .query("Camera")
+            .intersect::<Transform>(Access::Write)
+            .intersect::<CameraComponent>(Access::Write)
+            .finish()
             .build();
 
         let left_hand = io
@@ -111,7 +113,7 @@ impl Camera {
             self.arcball_control.update(&self.input, &mut self.arcball);
 
             // Set camera transform to arcball position
-            for key in query.iter() {
+            for key in query.iter("Camera") {
                 query.write::<Transform>(key, &self.arcball.camera_transf());
             }
         }
@@ -120,7 +122,7 @@ impl Camera {
 
         let clear_color = [0.; 3];
 
-        for key in query.iter() {
+        for key in query.iter("Camera") {
             query.write::<CameraComponent>(
                 key,
                 &CameraComponent {

--- a/example_plugins/camera/src/lib.rs
+++ b/example_plugins/camera/src/lib.rs
@@ -46,7 +46,8 @@ impl UserState for Camera {
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
             .subscribe::<VrUpdate>()
-            .query("Camera",
+            .query(
+                "Camera",
                 Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<CameraComponent>(Access::Write),

--- a/example_plugins/camera/src/lib.rs
+++ b/example_plugins/camera/src/lib.rs
@@ -46,10 +46,11 @@ impl UserState for Camera {
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
             .subscribe::<VrUpdate>()
-            .query("Camera")
-            .intersect::<Transform>(Access::Write)
-            .intersect::<CameraComponent>(Access::Write)
-            .qcommit()
+            .query(
+                Query::new("Camera")
+                    .intersect::<Transform>(Access::Write)
+                    .intersect::<CameraComponent>(Access::Write),
+            )
             .build();
 
         let left_hand = io

--- a/example_plugins/camera2d/src/lib.rs
+++ b/example_plugins/camera2d/src/lib.rs
@@ -24,8 +24,8 @@ impl UserState for Camera2D {
             .add_system(Self::update)
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
-            .query(
-                Query::new("Camera")
+            .query("Camera",
+                Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<CameraComponent>(Access::Write),
             )

--- a/example_plugins/camera2d/src/lib.rs
+++ b/example_plugins/camera2d/src/lib.rs
@@ -1,8 +1,5 @@
 use cimvr_common::{
-    render::CameraComponent,
-    utils::camera::Orthographic,
-    Transform,
-    desktop::{InputEvent},
+    desktop::InputEvent, render::CameraComponent, utils::camera::Orthographic, Transform,
 };
 use cimvr_engine_interface::{dbg, make_app_state, prelude::*};
 
@@ -27,10 +24,11 @@ impl UserState for Camera2D {
             .add_system(Self::update)
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
-            .query("Camera")
-                .intersect::<Transform>(Access::Write)
-                .intersect::<CameraComponent>(Access::Write)
-                .qcommit()
+            .query(
+                Query::new("Camera")
+                    .intersect::<Transform>(Access::Write)
+                    .intersect::<CameraComponent>(Access::Write),
+            )
             .build();
 
         Self {
@@ -41,9 +39,7 @@ impl UserState for Camera2D {
 
 impl Camera2D {
     fn update(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
-        
         for input in io.inbox::<InputEvent>() {
-
             // Provie the width and the height of the world application size
             self.proj.update_proj(80., 120., &input);
         }
@@ -54,7 +50,6 @@ impl Camera2D {
         for key in query.iter("Camera") {
             query.write::<Transform>(key, &self.proj.camera_on_positive_z_axis());
         }
-        
 
         for key in query.iter("Camera") {
             query.write::<CameraComponent>(

--- a/example_plugins/camera2d/src/lib.rs
+++ b/example_plugins/camera2d/src/lib.rs
@@ -24,7 +24,8 @@ impl UserState for Camera2D {
             .add_system(Self::update)
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
-            .query("Camera",
+            .query(
+                "Camera",
                 Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<CameraComponent>(Access::Write),

--- a/example_plugins/camera2d/src/lib.rs
+++ b/example_plugins/camera2d/src/lib.rs
@@ -23,14 +23,14 @@ impl UserState for Camera2D {
             .build();
 
         // Schedule the system
-        // In the future it would be super cool to do this like Bevy and be able to just infer the
-        // query from the type arguments and such...
         schedule
             .add_system(Self::update)
             .stage(Stage::PreUpdate)
             .subscribe::<InputEvent>()
-            .query::<Transform>(Access::Write)
-            .query::<CameraComponent>(Access::Write)
+            .query("Camera")
+                .intersect::<Transform>(Access::Write)
+                .intersect::<CameraComponent>(Access::Write)
+                .qcommit()
             .build();
 
         Self {
@@ -51,16 +51,16 @@ impl Camera2D {
         let clear_color = [0.; 3];
         let new_projection = self.proj.matrices();
 
-        for key in query.iter() {
+        for key in query.iter("Camera") {
             query.write::<Transform>(key, &self.proj.camera_on_positive_z_axis());
         }
         
 
-        for key in query.iter() {
+        for key in query.iter("Camera") {
             query.write::<CameraComponent>(
                 key,
                 &CameraComponent {
-                    clear_color: clear_color,
+                    clear_color,
                     projection: new_projection,
                 },
             );

--- a/example_plugins/chat/Cargo.toml
+++ b/example_plugins/chat/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cimvr_common = { path = "../../common" }

--- a/example_plugins/chat/src/lib.rs
+++ b/example_plugins/chat/src/lib.rs
@@ -17,18 +17,21 @@ struct ServerState {
 
 make_app_state!(ClientState, ServerState);
 
-/// Server to client chat message datatype
+/// Server to client chat message datatype;
+/// used to tell clients to display the given chat message
 #[derive(Message, Serialize, Deserialize, Debug)]
 #[locality("Remote")]
-struct ChatDownload {
-    username: String,
-    text: String,
+pub struct ChatDownload {
+    pub username: String,
+    pub text: String,
 }
 
-/// Client to server chat message datatype
+/// Client to server chat message datatype;
+/// used to tell the server to broadcast this chat message to all other clients
+/// The server will decide how to set the username of the corresponding ChatDownload
 #[derive(Message, Serialize, Deserialize, Debug)]
 #[locality("Remote")]
-struct ChatUpload(String);
+pub struct ChatUpload(pub String);
 
 /// Number of chat log messages
 const N_DISPLAYED_MESSAGES: usize = 5;

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -35,8 +35,8 @@ impl UserState for ServerState {
         sched
             .add_system(Self::cube_move)
             .subscribe::<FrameTime>()
-            .query(
-                Query::new("Cubes")
+            .query("Cubes",
+                Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<MoveCube>(Access::Read),
             )
@@ -45,7 +45,7 @@ impl UserState for ServerState {
         sched
             .add_system(Self::startup)
             .stage(Stage::PostInit)
-            .query(Query::new("Cube").intersect::<MoveCube>(Access::Read))
+            .query("Cube",Query::new().intersect::<MoveCube>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -35,18 +35,17 @@ impl UserState for ServerState {
         sched
             .add_system(Self::cube_move)
             .subscribe::<FrameTime>()
-            .query("Cubes")
-            .intersect::<Transform>(Access::Write)
-            .intersect::<MoveCube>(Access::Read)
-            .qcommit()
+            .query(
+                Query::new("Cubes")
+                    .intersect::<Transform>(Access::Write)
+                    .intersect::<MoveCube>(Access::Read),
+            )
             .build();
 
         sched
             .add_system(Self::startup)
             .stage(Stage::PostInit)
-            .query("Cube")
-            .intersect::<MoveCube>(Access::Read)
-            .qcommit()
+            .query(Query::new("Cube").intersect::<MoveCube>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -38,7 +38,7 @@ impl UserState for ServerState {
             .query("Cubes")
             .intersect::<Transform>(Access::Write)
             .intersect::<MoveCube>(Access::Read)
-            .finish()
+            .qcommit()
             .build();
 
         sched
@@ -46,7 +46,7 @@ impl UserState for ServerState {
             .stage(Stage::PostInit)
             .query("Cube")
             .intersect::<MoveCube>(Access::Read)
-            .finish()
+            .qcommit()
             .build();
 
         Self

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -35,14 +35,18 @@ impl UserState for ServerState {
         sched
             .add_system(Self::cube_move)
             .subscribe::<FrameTime>()
-            .query::<Transform>(Access::Write)
-            .query::<MoveCube>(Access::Read)
+            .query("Cubes")
+            .intersect::<Transform>(Access::Write)
+            .intersect::<MoveCube>(Access::Read)
+            .finish()
             .build();
 
         sched
             .add_system(Self::startup)
             .stage(Stage::PostInit)
-            .query::<MoveCube>(Access::Read)
+            .query("Cube")
+            .intersect::<MoveCube>(Access::Read)
+            .finish()
             .build();
 
         Self
@@ -51,10 +55,6 @@ impl UserState for ServerState {
 
 impl ServerState {
     fn startup(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
-        for k in query.iter() {
-            io.remove_entity(k);
-        }
-
         // Cube mesh
         let cube_rdr = Render::new(CUBE_HANDLE)
             .primitive(Primitive::Lines)
@@ -85,7 +85,7 @@ impl ServerState {
 
     fn cube_move(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
         if let Some(FrameTime { time, .. }) = io.inbox_first() {
-            for key in query.iter() {
+            for key in query.iter("Cubes") {
                 let mov = query.read::<MoveCube>(key);
 
                 let theta = mov.r + time / 10.;

--- a/example_plugins/dancing_cubes/src/lib.rs
+++ b/example_plugins/dancing_cubes/src/lib.rs
@@ -35,7 +35,8 @@ impl UserState for ServerState {
         sched
             .add_system(Self::cube_move)
             .subscribe::<FrameTime>()
-            .query("Cubes",
+            .query(
+                "Cubes",
                 Query::new()
                     .intersect::<Transform>(Access::Write)
                     .intersect::<MoveCube>(Access::Read),
@@ -45,7 +46,7 @@ impl UserState for ServerState {
         sched
             .add_system(Self::startup)
             .stage(Stage::PostInit)
-            .query("Cube",Query::new().intersect::<MoveCube>(Access::Read))
+            .query("Cube", Query::new().intersect::<MoveCube>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -34,9 +34,7 @@ impl UserState for ServerState {
         // Queries all entities with MyComponent attached, and allows us to write to them
         sched
             .add_system(Self::update)
-            .query("My Query Name")
-            .intersect::<MyComponent>(Access::Write)
-            .qcommit()
+            .query(Query::new("My Query Name").intersect::<MyComponent>(Access::Write))
             .build();
 
         Self { increment: 0 }

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -34,7 +34,7 @@ impl UserState for ServerState {
         // Queries all entities with MyComponent attached, and allows us to write to them
         sched
             .add_system(Self::update)
-            .query(Query::new("My Query Name").intersect::<MyComponent>(Access::Write))
+            .query("My Query Name",Query::new().intersect::<MyComponent>(Access::Write))
             .build();
 
         Self { increment: 0 }
@@ -66,7 +66,7 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query(Query::new("My other query").intersect::<MyComponent>(Access::Read))
+            .query("My other query",Query::new().intersect::<MyComponent>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -34,7 +34,10 @@ impl UserState for ServerState {
         // Queries all entities with MyComponent attached, and allows us to write to them
         sched
             .add_system(Self::update)
-            .query("My Query Name",Query::new().intersect::<MyComponent>(Access::Write))
+            .query(
+                "My Query Name",
+                Query::new().intersect::<MyComponent>(Access::Write),
+            )
             .build();
 
         Self { increment: 0 }
@@ -66,7 +69,10 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query("My other query",Query::new().intersect::<MyComponent>(Access::Read))
+            .query(
+                "My other query",
+                Query::new().intersect::<MyComponent>(Access::Read),
+            )
             .build();
 
         Self

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -36,7 +36,7 @@ impl UserState for ServerState {
             .add_system(Self::update)
             .query("My Query Name")
             .intersect::<MyComponent>(Access::Write)
-            .finish()
+            .qcommit()
             .build();
 
         Self { increment: 0 }
@@ -70,7 +70,7 @@ impl UserState for ClientState {
             .add_system(Self::update)
             .query("My other query")
             .intersect::<MyComponent>(Access::Read)
-            .finish()
+            .qcommit()
             .build();
 
         Self

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -34,7 +34,9 @@ impl UserState for ServerState {
         // Queries all entities with MyComponent attached, and allows us to write to them
         sched
             .add_system(Self::update)
-            .query::<MyComponent>(Access::Write)
+            .query("My Query Name")
+            .intersect::<MyComponent>(Access::Write)
+            .finish()
             .build();
 
         Self { increment: 0 }
@@ -44,7 +46,8 @@ impl UserState for ServerState {
 impl ServerState {
     fn update(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
         // Update MyComponent, which is then automatically Sychronized with the connected clients
-        for key in query.iter() {
+        // Note that we re-use the string "My Query Name" to refer to the query we
+        for key in query.iter("My Query Name") {
             query.write(
                 key,
                 &MyComponent {
@@ -65,7 +68,9 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query::<MyComponent>(Access::Read)
+            .query("My other query")
+            .intersect::<MyComponent>(Access::Read)
+            .finish()
             .build();
 
         Self
@@ -75,7 +80,7 @@ impl UserState for ClientState {
 impl ClientState {
     fn update(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
         // Write all MyComponents to the console
-        for key in query.iter() {
+        for key in query.iter("My other query") {
             dbg!(query.read::<MyComponent>(key));
         }
     }

--- a/example_plugins/ecs/src/lib.rs
+++ b/example_plugins/ecs/src/lib.rs
@@ -66,9 +66,7 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query("My other query")
-            .intersect::<MyComponent>(Access::Read)
-            .qcommit()
+            .query(Query::new("My other query").intersect::<MyComponent>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -62,7 +62,7 @@ impl UserState for ServerState {
             .query("Spinning cubes")
             .intersect::<SpinningCube>(Access::Read)
             .intersect::<Transform>(Access::Write)
-            .finish()
+            .qcommit()
             .subscribe::<AxisMessage>()
             .subscribe::<Connections>()
             .build();

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -59,8 +59,10 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query::<SpinningCube>(Access::Read)
-            .query::<Transform>(Access::Write)
+            .query("Spinning cubes")
+            .intersect::<SpinningCube>(Access::Read)
+            .intersect::<Transform>(Access::Write)
+            .finish()
             .subscribe::<AxisMessage>()
             .subscribe::<Connections>()
             .build();
@@ -79,7 +81,7 @@ impl ServerState {
         // For each entity mapping to a client that we know about, store the mapping
         // client -> entity
         // If the entity exists but the client doesn't, remove the entity
-        for key in query.iter() {
+        for key in query.iter("Spinning cubes") {
             let SpinningCube(client_id) = query.read::<SpinningCube>(key);
             if conns.clients.iter().find(|c| c.id == client_id).is_some() {
                 client_to_entity.insert(client_id, key);

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -59,8 +59,8 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query(
-                Query::new("Spinning cubes")
+            .query("Spinning cubes",
+                Query::new()
                     .intersect::<SpinningCube>(Access::Read)
                     .intersect::<Transform>(Access::Write),
             )

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -59,10 +59,11 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query("Spinning cubes")
-            .intersect::<SpinningCube>(Access::Read)
-            .intersect::<Transform>(Access::Write)
-            .qcommit()
+            .query(
+                Query::new("Spinning cubes")
+                    .intersect::<SpinningCube>(Access::Read)
+                    .intersect::<Transform>(Access::Write),
+            )
             .subscribe::<AxisMessage>()
             .subscribe::<Connections>()
             .build();

--- a/example_plugins/gamepad/src/lib.rs
+++ b/example_plugins/gamepad/src/lib.rs
@@ -59,7 +59,8 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query("Spinning cubes",
+            .query(
+                "Spinning cubes",
                 Query::new()
                     .intersect::<SpinningCube>(Access::Read)
                     .intersect::<Transform>(Access::Write),

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -106,7 +106,7 @@ impl UserState for ServerState {
             .query("Cubes")
             .intersect::<CubeFlag>(Access::Write)
             .intersect::<Transform>(Access::Write)
-            .finish()
+            .qcommit()
             .build();
 
         Self

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -103,7 +103,8 @@ impl UserState for ServerState {
         sched
             .add_system(Self::update)
             .subscribe::<MoveCommand>()
-            .query("Cubes",
+            .query(
+                "Cubes",
                 Query::new()
                     .intersect::<CubeFlag>(Access::Write)
                     .intersect::<Transform>(Access::Write),

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -103,8 +103,10 @@ impl UserState for ServerState {
         sched
             .add_system(Self::update)
             .subscribe::<MoveCommand>()
-            .query::<CubeFlag>(Access::Write)
-            .query::<Transform>(Access::Write)
+            .query("Cubes")
+            .intersect::<CubeFlag>(Access::Write)
+            .intersect::<Transform>(Access::Write)
+            .finish()
             .build();
 
         Self
@@ -116,7 +118,7 @@ impl ServerState {
         // Check for movement commands
         if let Some(MoveCommand { distance }) = io.inbox_first() {
             // Update each object accordingly
-            for key in query.iter() {
+            for key in query.iter("Cubes") {
                 query.modify::<Transform>(key, |tf| {
                     tf.pos += distance;
                 })

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -103,10 +103,11 @@ impl UserState for ServerState {
         sched
             .add_system(Self::update)
             .subscribe::<MoveCommand>()
-            .query("Cubes")
-            .intersect::<CubeFlag>(Access::Write)
-            .intersect::<Transform>(Access::Write)
-            .qcommit()
+            .query(
+                Query::new("Cubes")
+                    .intersect::<CubeFlag>(Access::Write)
+                    .intersect::<Transform>(Access::Write),
+            )
             .build();
 
         Self

--- a/example_plugins/keyboard/src/lib.rs
+++ b/example_plugins/keyboard/src/lib.rs
@@ -103,8 +103,8 @@ impl UserState for ServerState {
         sched
             .add_system(Self::update)
             .subscribe::<MoveCommand>()
-            .query(
-                Query::new("Cubes")
+            .query("Cubes",
+                Query::new()
                     .intersect::<CubeFlag>(Access::Write)
                     .intersect::<Transform>(Access::Write),
             )

--- a/example_plugins/multiple_queries/.cargo/config.toml
+++ b/example_plugins/multiple_queries/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"   
+
+[alias]
+test_pc = "test --target=x86_64-unknown-linux-gnu"

--- a/example_plugins/multiple_queries/.gitignore
+++ b/example_plugins/multiple_queries/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/example_plugins/multiple_queries/Cargo.toml
+++ b/example_plugins/multiple_queries/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "multiple_queries"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+cimvr_common = { path = "../../common" }
+cimvr_engine_interface = { path = "../../engine_interface" }
+serde = { version = "1", features = ["derive"] }

--- a/example_plugins/multiple_queries/src/lib.rs
+++ b/example_plugins/multiple_queries/src/lib.rs
@@ -30,12 +30,8 @@ impl UserState for ServerState {
 
         sched
             .add_system(Self::update)
-            .query("My Query Name")
-            .intersect::<MyComponent>(Access::Write)
-            .qcommit()
-            .query("My Other Query Name")
-            .intersect::<MyOtherComponent>(Access::Write)
-            .qcommit()
+            .query(Query::new("My Query Name").intersect::<MyComponent>(Access::Write))
+            .query(Query::new("My Other Query Name").intersect::<MyOtherComponent>(Access::Write))
             .build();
 
         Self { increment: 0 }
@@ -71,12 +67,8 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query("My query")
-            .intersect::<MyComponent>(Access::Read)
-            .qcommit()
-            .query("My other query")
-            .intersect::<MyOtherComponent>(Access::Read)
-            .qcommit()
+            .query(Query::new("My query").intersect::<MyComponent>(Access::Read))
+            .query(Query::new("My other query").intersect::<MyOtherComponent>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/multiple_queries/src/lib.rs
+++ b/example_plugins/multiple_queries/src/lib.rs
@@ -32,10 +32,10 @@ impl UserState for ServerState {
             .add_system(Self::update)
             .query("My Query Name")
             .intersect::<MyComponent>(Access::Write)
-            .finish()
+            .qcommit()
             .query("My Other Query Name")
             .intersect::<MyOtherComponent>(Access::Write)
-            .finish()
+            .qcommit()
             .build();
 
         Self { increment: 0 }
@@ -73,10 +73,10 @@ impl UserState for ClientState {
             .add_system(Self::update)
             .query("My query")
             .intersect::<MyComponent>(Access::Read)
-            .finish()
+            .qcommit()
             .query("My other query")
             .intersect::<MyOtherComponent>(Access::Read)
-            .finish()
+            .qcommit()
             .build();
 
         Self

--- a/example_plugins/multiple_queries/src/lib.rs
+++ b/example_plugins/multiple_queries/src/lib.rs
@@ -1,0 +1,96 @@
+use cimvr_engine_interface::{dbg, make_app_state, pkg_namespace, prelude::*};
+use serde::{Deserialize, Serialize};
+
+struct ClientState;
+
+struct ServerState {
+    increment: i32,
+}
+
+make_app_state!(ClientState, ServerState);
+
+#[derive(Component, Serialize, Deserialize, Default, Clone, Copy, Debug)]
+struct MyComponent {
+    a: i32,
+    b: f32,
+}
+
+#[derive(Component, Serialize, Deserialize, Default, Clone, Copy, Debug)]
+struct MyOtherComponent {
+    frogge: u128,
+}
+
+impl UserState for ServerState {
+    fn new(io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
+        io.create_entity()
+            .add_component(MyComponent { a: 0, b: 0.0 })
+            .add_component(MyOtherComponent { frogge: u128::MAX })
+            .add_component(Synchronized)
+            .build();
+
+        sched
+            .add_system(Self::update)
+            .query("My Query Name")
+            .intersect::<MyComponent>(Access::Write)
+            .finish()
+            .query("My Other Query Name")
+            .intersect::<MyOtherComponent>(Access::Write)
+            .finish()
+            .build();
+
+        Self { increment: 0 }
+    }
+}
+
+impl ServerState {
+    fn update(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
+        // Update MyComponent, which is then automatically Sychronized with the connected clients
+        // Note that we re-use the string "My Query Name" to refer to the query we
+        for key in query.iter("My Query Name") {
+            query.write(
+                key,
+                &MyComponent {
+                    a: self.increment,
+                    b: self.increment as f32,
+                },
+            );
+        }
+
+        for key in query.iter("My Other Query Name") {
+            query.write(key, &MyOtherComponent { frogge: 0 });
+        }
+
+        self.increment += 1;
+    }
+}
+
+// Client code
+impl UserState for ClientState {
+    fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
+        // Schedule the update() system to run every Update,
+        // querying all entities with the MyComponent component attached
+        sched
+            .add_system(Self::update)
+            .query("My query")
+            .intersect::<MyComponent>(Access::Read)
+            .finish()
+            .query("My other query")
+            .intersect::<MyOtherComponent>(Access::Read)
+            .finish()
+            .build();
+
+        Self
+    }
+}
+
+impl ClientState {
+    fn update(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
+        for key in query.iter("My query") {
+            dbg!(query.read::<MyComponent>(key));
+        }
+
+        for key in query.iter("My other query") {
+            dbg!(query.read::<MyOtherComponent>(key));
+        }
+    }
+}

--- a/example_plugins/multiple_queries/src/lib.rs
+++ b/example_plugins/multiple_queries/src/lib.rs
@@ -30,8 +30,14 @@ impl UserState for ServerState {
 
         sched
             .add_system(Self::update)
-            .query("My Query Name",Query::new().intersect::<MyComponent>(Access::Write))
-            .query("My Other Query Name",Query::new().intersect::<MyOtherComponent>(Access::Write))
+            .query(
+                "My Query Name",
+                Query::new().intersect::<MyComponent>(Access::Write),
+            )
+            .query(
+                "My Other Query Name",
+                Query::new().intersect::<MyOtherComponent>(Access::Write),
+            )
             .build();
 
         Self { increment: 0 }
@@ -67,8 +73,14 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query("My query",Query::new().intersect::<MyComponent>(Access::Read))
-            .query("My other query",Query::new().intersect::<MyOtherComponent>(Access::Read))
+            .query(
+                "My query",
+                Query::new().intersect::<MyComponent>(Access::Read),
+            )
+            .query(
+                "My other query",
+                Query::new().intersect::<MyOtherComponent>(Access::Read),
+            )
             .build();
 
         Self

--- a/example_plugins/multiple_queries/src/lib.rs
+++ b/example_plugins/multiple_queries/src/lib.rs
@@ -30,8 +30,8 @@ impl UserState for ServerState {
 
         sched
             .add_system(Self::update)
-            .query(Query::new("My Query Name").intersect::<MyComponent>(Access::Write))
-            .query(Query::new("My Other Query Name").intersect::<MyOtherComponent>(Access::Write))
+            .query("My Query Name",Query::new().intersect::<MyComponent>(Access::Write))
+            .query("My Other Query Name",Query::new().intersect::<MyOtherComponent>(Access::Write))
             .build();
 
         Self { increment: 0 }
@@ -67,8 +67,8 @@ impl UserState for ClientState {
         // querying all entities with the MyComponent component attached
         sched
             .add_system(Self::update)
-            .query(Query::new("My query").intersect::<MyComponent>(Access::Read))
-            .query(Query::new("My other query").intersect::<MyOtherComponent>(Access::Read))
+            .query("My query",Query::new().intersect::<MyComponent>(Access::Read))
+            .query("My other query",Query::new().intersect::<MyOtherComponent>(Access::Read))
             .build();
 
         Self

--- a/example_plugins/shader/src/lib.rs
+++ b/example_plugins/shader/src/lib.rs
@@ -59,7 +59,7 @@ void main() {
 "#;
 
 impl UserState for ClientState {
-    fn new(io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
+    fn new(io: &mut EngineIo, _sched: &mut EngineSchedule<Self>) -> Self {
         // Make the cube mesh available to the rendering engine
         io.send(&UploadMesh {
             mesh: cube(),
@@ -72,22 +72,7 @@ impl UserState for ClientState {
             id: CUBE_SHADER,
         });
 
-        sched
-            .add_system(Self::deleteme)
-            .query::<RenderExtra>(Access::Read)
-            .query::<Synchronized>(Access::Read)
-            .build();
-
         Self
-    }
-}
-
-impl ClientState {
-    fn deleteme(&mut self, _io: &mut EngineIo, query: &mut QueryResult) {
-        for key in query.iter() {
-            let time = query.read::<RenderExtra>(key).0[0];
-            dbg!((time, key));
-        }
     }
 }
 

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -11,7 +11,7 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query(Query::new("Color changers").intersect::<Render>(Access::Read))
+            .query("Color changers",Query::new().intersect::<Render>(Access::Read))
             .subscribe::<UiUpdate>()
             .subscribe::<ChangeColor>()
             .build();

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -11,9 +11,7 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query("Color changers")
-            .intersect::<Render>(Access::Read)
-            .qcommit()
+            .query(Query::new("Color changers").intersect::<Render>(Access::Read))
             .subscribe::<UiUpdate>()
             .subscribe::<ChangeColor>()
             .build();

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -11,7 +11,9 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query::<Render>(Access::Read)
+            .query("Color changers")
+            .intersect::<Render>(Access::Read)
+            .finish()
             .subscribe::<UiUpdate>()
             .subscribe::<ChangeColor>()
             .build();
@@ -23,7 +25,7 @@ impl UserState for ServerState {
 impl ServerState {
     fn update(&mut self, io: &mut EngineIo, query: &mut QueryResult) {
         if let Some(ChangeColor { rgb }) = io.inbox_first() {
-            for ent in query.iter() {
+            for ent in query.iter("Color changers") {
                 // The default shader uses RenderExtra to set the color
                 let mut extra = [0.; 4 * 4];
                 extra[..3].copy_from_slice(&rgb);

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -13,7 +13,7 @@ impl UserState for ServerState {
             .add_system(Self::update)
             .query("Color changers")
             .intersect::<Render>(Access::Read)
-            .finish()
+            .qcommit()
             .subscribe::<UiUpdate>()
             .subscribe::<ChangeColor>()
             .build();

--- a/example_plugins/ui_example/src/server.rs
+++ b/example_plugins/ui_example/src/server.rs
@@ -11,7 +11,10 @@ impl UserState for ServerState {
     fn new(_io: &mut EngineIo, sched: &mut EngineSchedule<Self>) -> Self {
         sched
             .add_system(Self::update)
-            .query("Color changers",Query::new().intersect::<Render>(Access::Read))
+            .query(
+                "Color changers",
+                Query::new().intersect::<Render>(Access::Read),
+            )
             .subscribe::<UiUpdate>()
             .subscribe::<ChangeColor>()
             .build();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use cimvr_engine::hotload::Hotloader;
 use cimvr_engine::interface::prelude::{
-    Access, ClientId, ConnectionRequest, Connections, QueryComponent, Synchronized,
+    Access, ClientId, ConnectionRequest, Connections, Synchronized, Query,
 };
 use cimvr_engine::interface::serial::deserialize;
 use cimvr_engine::Config;
@@ -197,7 +197,7 @@ impl Server {
             ecs: self
                 .engine
                 .ecs()
-                .export(&[QueryComponent::new::<Synchronized>(Access::Read)]),
+                .export(&Query::new("Synchronized").intersect::<Synchronized>(Access::Read)),
             messages: self.engine.network_inbox(),
         };
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use cimvr_engine::hotload::Hotloader;
 use cimvr_engine::interface::prelude::{
-    Access, ClientId, ConnectionRequest, Connections, Synchronized, Query,
+    Access, ClientId, ConnectionRequest, Connections, Query, Synchronized,
 };
 use cimvr_engine::interface::serial::deserialize;
 use cimvr_engine::Config;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -197,7 +197,7 @@ impl Server {
             ecs: self
                 .engine
                 .ecs()
-                .export(&Query::new("Synchronized").intersect::<Synchronized>(Access::Read)),
+                .export(&Query::new().intersect::<Synchronized>(Access::Read)),
             messages: self.engine.network_inbox(),
         };
 

--- a/tools/compile_everything.sh
+++ b/tools/compile_everything.sh
@@ -1,10 +1,16 @@
 pushd client
-cargo b -r
-popd
+if cargo b -r; then
+    popd
+else
+    exit
+fi
 
 pushd server
-cargo b -r
-popd
+if cargo b -r; then
+    popd
+else
+    exit
+fi
 
 pushd example_plugins
 ./compile_all.sh


### PR DESCRIPTION
Allows one to make multiple queries from a single system. See the `multiple_queries` example!

This is a breaking change. Queries now have names; individual queries are declared like so:
```rust
sched
    .add_system(Self::update)
    .query(Query::new("My Query Name")
        .intersect::<MyComponent>(Access::Write))
    .query(Query::new("My Other Query Name")
        .intersect::<MyOtherComponent>(Access::Write))
    .build();
```

Queries are then referenced by their name:
```rust
for key in query.iter("My Query Name") {
    // ...
}
```