### PR TITLE
Add methods for render and upload to MeshHandle

### DIFF
--- a/common/src/render.rs
+++ b/common/src/render.rs
@@ -47,6 +47,7 @@ pub struct CameraComponent {
 }
 
 /// All information required to define a renderable mesh
+#[must_use]
 #[derive(Message, Serialize, Deserialize, Debug, Clone)]
 #[locality("Local")]
 pub struct UploadMesh {
@@ -191,5 +192,17 @@ impl Default for CameraComponent {
             clear_color: [0.; 3],
             projection: [Mat4::IDENTITY; 2],
         }
+    }
+}
+
+impl MeshHandle {
+    /// Returns an appropriate Render component.
+    pub fn render(self) -> Render {
+        Render::new(self)
+    }
+
+    /// Returns an appropriate UploadMesh message.
+    pub fn upload(self, mesh: Mesh) -> UploadMesh {
+        UploadMesh { mesh, id: self }
     }
 }

--- a/example_plugins/cube/src/lib.rs
+++ b/example_plugins/cube/src/lib.rs
@@ -19,10 +19,7 @@ impl UserState for ClientState {
     fn new(io: &mut EngineIo, _sched: &mut EngineSchedule<Self>) -> Self {
         // Make the cube mesh available to the rendering engine
         // This defines the CUBE_HANDLE id to refer to the mesh we get from cube()
-        io.send(&UploadMesh {
-            mesh: cube(),
-            id: CUBE_HANDLE,
-        });
+        io.send(&CUBE_HANDLE.upload(cube()));
 
         Self
     }
@@ -37,7 +34,7 @@ impl UserState for ServerState {
             .add_component(Transform::default())
             // Attach the Render component, which details how the object should be drawn
             // Note that we use CUBE_HANDLE here, to tell the rendering engine to draw the cube
-            .add_component(Render::new(CUBE_HANDLE).primitive(Primitive::Triangles))
+            .add_component(CUBE_HANDLE.render().primitive(Primitive::Triangles))
             // Attach the Synchronized component, which will copy the object to clients
             .add_component(Synchronized)
             // And get the entity ID


### PR DESCRIPTION
Slightly improved interface for interfacing with MeshHandle this pattern could be used elsewhere also.
```rust
io.send(&CUBE_HANDLE.upload(cube()));
```
```rust
io.create_entity()
    .add_component(CUBE_HANDLE.render().primitive(Primitive::Triangles))
    // ... 
```