### PR TITLE
Add 'cimvr new' subcommand to cimvr.py

### DIFF
--- a/obj_loader/src/obj.rs
+++ b/obj_loader/src/obj.rs
@@ -149,4 +149,3 @@ pub fn obj_lines_to_mesh(obj: &str) -> Mesh {
 
     m
 }
-


### PR DESCRIPTION
Adds a subcommand to cimvr.py which clones the template repository and changes the name in Cargo.toml to match the name of the project. Another option would be to wrap `cargo new` and have it add needed files and append deps to Cargo.toml, but that was more work. Had assistance from ChatGPT working out the details!